### PR TITLE
fix: delete de user não retorna um falso sucesso ao deletar usuário com id que não existe

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,10 @@
+## TODO
+
+Lista com ideias que eu desejo analisar para adicionar ao sistema, e problemas que eu encontrei e não pude resolver no momento
+ou que precisava de mais tempo para pensar.
+
+### fix
+
+- Não é possível deletar um usuário que tenha incomes/expenses através do endpoint DELETE /api/users/{ID}.
+  Porque o user_id é chave extrangeira nas tabelas income e expense.
+    - Pensar em como será feita essa exclusão de user e das linhas relacionadas a user.

--- a/src/main/java/br/com/emendes/financesapi/service/impl/UserServiceImpl.java
+++ b/src/main/java/br/com/emendes/financesapi/service/impl/UserServiceImpl.java
@@ -13,13 +13,14 @@ import br.com.emendes.financesapi.service.UserService;
 import br.com.emendes.financesapi.util.AuthenticationFacade;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DataIntegrityViolationException;
-import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
+@Slf4j
 @RequiredArgsConstructor
 @Service
 public class UserServiceImpl implements UserService {
@@ -55,11 +56,14 @@ public class UserServiceImpl implements UserService {
 
   @Override
   public void delete(Long id) {
-    try {
-      userRepository.deleteById(id);
-    } catch (EmptyResultDataAccessException e) {
-      throw new EntityNotFoundException("User not found with id " + id);
-    }
+    log.info("attempt to delete user with id: {}", id);
+    User user = userRepository.findById(id).orElseThrow(() -> {
+      log.info("user not found with id: {}", id);
+      return new EntityNotFoundException("User not found with id " + id);
+    });
+
+    userRepository.delete(user);
+    log.info("user deleted successfully with id: {}", id);
   }
 
   @Override

--- a/src/test/java/br/com/emendes/financesapi/util/faker/RoleFaker.java
+++ b/src/test/java/br/com/emendes/financesapi/util/faker/RoleFaker.java
@@ -1,0 +1,20 @@
+package br.com.emendes.financesapi.util.faker;
+
+import br.com.emendes.financesapi.model.entity.Role;
+
+/**
+ * Classe com objetos relacionados a Role para serem usados em testes automatizados.
+ */
+public class RoleFaker {
+
+  /**
+   * Retorna uma Role com todos os dados e nome igual USER_ROLE.
+   */
+  public static Role userRole() {
+    return Role.builder()
+        .id(1)
+        .name("USER_ROLE")
+        .build();
+  }
+
+}

--- a/src/test/java/br/com/emendes/financesapi/util/faker/UserFaker.java
+++ b/src/test/java/br/com/emendes/financesapi/util/faker/UserFaker.java
@@ -1,0 +1,35 @@
+package br.com.emendes.financesapi.util.faker;
+
+import br.com.emendes.financesapi.model.entity.User;
+
+import java.util.List;
+import java.util.Optional;
+
+import static br.com.emendes.financesapi.util.faker.RoleFaker.userRole;
+
+/**
+ * Classe com objetos relacionados a User para serem usados em testes automatizados.
+ */
+public class UserFaker {
+
+  /**
+   * Retorna um User com todos os dados.
+   */
+  public static User user() {
+    return User.builder()
+        .id(1_000L)
+        .name("John Doe")
+        .email("john.doe@email.com")
+        .password("1234567890")
+        .roles(List.of(userRole()))
+        .build();
+  }
+
+  /**
+   * Retorna um {@code Optional<User>} que contém um User.
+   */
+  public static Optional<User> optionalUser() {
+    return Optional.ofNullable(user());
+  }
+
+}


### PR DESCRIPTION
Bug:
Ao tentar deletar um usuário que não existe pelo endpoint **DELETE /api/users/{ID}**, uma resposta com status 204 (sucesso) é devolvida ao cliente, mesmo que não exista usuário com o ID informado.

O que foi feito:
- Delete de user não retorna um falso sucesso ao deletar usuário com id que não existe
  - Ao tentar deletar usuário, é feita uma verificação se existe usuário com o dado ID, caso exista, o usuário é deletado, caso contrário uma exception EntityNotFound é lançada e tratada por um handler.
- Ajuste dos testes de unidade relacionado ao delete de user