### PR TITLE
refact: desacoplando as queries de ExpenseRepository do usuário autenticado no sistema

### DIFF
--- a/src/main/java/br/com/emendes/financesapi/repository/ExpenseRepository.java
+++ b/src/main/java/br/com/emendes/financesapi/repository/ExpenseRepository.java
@@ -2,6 +2,7 @@ package br.com.emendes.financesapi.repository;
 
 import br.com.emendes.financesapi.dto.response.ValueByCategoryResponse;
 import br.com.emendes.financesapi.model.entity.Expense;
+import br.com.emendes.financesapi.model.entity.User;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -13,28 +14,120 @@ import java.util.Optional;
 
 public interface ExpenseRepository extends JpaRepository<Expense, Long> {
 
+  @Deprecated
   @Query("SELECT e FROM Expense e WHERE e.user.id = ?#{ principal?.id }")
   Page<Expense> findAllByUser(Pageable pageable);
 
+  /**
+   * Busca paginada de despesas (expenses) para um dado usuário (user).
+   *
+   * @param user     usuário relacionado com as despesas a serem buscadas.
+   * @param pageable objeto que define como será a paginação (page, size e sort).
+   * @return Objeto {@code Page<Expense>} com as despesas encontradas para o dado user e pageable.
+   */
+  @Query("SELECT e FROM Expense e WHERE e.user = :user")
+  Page<Expense> findAllByUser(@Param("user") User user, Pageable pageable);
+
+  @Deprecated
   @Query("SELECT e FROM Expense e " +
-      "WHERE lower_unaccent(e.description) LIKE lower_unaccent('%' || :description || '%') " +
-      "AND e.user.id = ?#{ principal?.id }")
+         "WHERE lower_unaccent(e.description) LIKE lower_unaccent('%' || :description || '%') " +
+         "AND e.user.id = ?#{ principal?.id }")
   Page<Expense> findByDescriptionAndUser(@Param("description") String description, Pageable pageable);
 
-  @Query("SELECT e FROM Expense e " +
-      "WHERE YEAR(e.date) = :year AND MONTH(e.date)= :month AND e.user.id = ?#{ principal?.id }")
+  /**
+   * Busca paginada de despesas (expenses) para um dado usuário (user) e descrição (description).<br>
+   * <br>
+   * OBS: A descrição da despesa não precisa ser igual a description passada como parâmetro, e sim conte-la.
+   * Ou seja, uma description 'Supermercado Zaffari' seria buscada por exêmplo para parâmetros 'mercado', 'zaffari', 'super'.
+   *
+   * @param description descrição que as despesas devem conter para serem buscadas.
+   * @param pageable    objeto que define como será feito a paginação (page, size e sort).
+   * @param user        usuário relacionado com as despesas a serem buscadas.
+   * @return Objeto {@code Page<Expense>} com as despesas encontradas para o dado user, description e pageable.
+   */
+  @Query("""
+      SELECT e FROM Expense e
+        WHERE lower(unaccent(e.description)) LIKE lower(unaccent('%' || :description || '%'))
+        AND e.user = :user
+      """)
+  Page<Expense> findByDescriptionAndUser(
+      @Param("description") String description,
+      @Param("user") User user,
+      Pageable pageable);
+
+  @Deprecated
+  @Query("""
+      SELECT e FROM Expense e
+        WHERE YEAR(e.date) = :year
+        AND MONTH(e.date)= :month
+        AND e.user.id = ?#{ principal?.id }
+      """)
   Page<Expense> findByYearAndMonthAndUser(
       @Param("year") int year,
       @Param("month") int month,
       Pageable pageable);
 
+  /**
+   * Busca paginada de despesas (expenses) por ano (year), mês (month) e usuário (user).
+   *
+   * @param year     ano em que foi feito a despesa.
+   * @param month    mês em que foi feito a despesa.
+   * @param user     usuário relacionado com as despesas a serem buscadas.
+   * @param pageable objeto que define como será feito a paginação (page, size e sort).
+   * @return Objeto {@code Page<Expense>} com as despesas que satisfação as restrições acima.
+   */
+  @Query("""
+      SELECT e FROM Expense e
+        WHERE YEAR(e.date) = :year
+        AND MONTH(e.date) = :month
+        AND e.user = :user
+      """)
+  Page<Expense> findByYearAndMonthAndUser(
+      @Param("year") int year,
+      @Param("month") int month,
+      @Param("user") User user,
+      Pageable pageable);
+
+  @Deprecated
   @Query("SELECT e FROM Expense e WHERE e.id = :id AND e.user.id = ?#{ principal?.id }")
   Optional<Expense> findByIdAndUser(@Param("id") Long id);
 
+  /**
+   * Busca despesa (expense) por id e user.
+   *
+   * @param id   identificador da despesa.
+   * @param user usuário relacionado com a despesa a ser buscada.
+   * @return Objeto {@code Optional<Expense>} com a despesa encontrada, ou empty caso contrário.
+   */
+  @Query("SELECT e FROM Expense e WHERE e.id = :id AND e.user = :user")
+  Optional<Expense> findByIdAndUser(@Param("id") Long id, @Param("user") User user);
+
+  @Deprecated
   @Query("SELECT new br.com.emendes.financesapi.dto.response.ValueByCategoryResponse(e.category, SUM(e.value)) " +
-      "FROM Expense e " +
-      "WHERE YEAR(e.date) = :year AND MONTH(e.date) = :month " +
-      "AND e.user.id = ?#{ principal?.id } " +
-      "GROUP BY e.category")
+         "FROM Expense e " +
+         "WHERE YEAR(e.date) = :year AND MONTH(e.date) = :month " +
+         "AND e.user.id = ?#{ principal?.id } " +
+         "GROUP BY e.category")
   List<ValueByCategoryResponse> getValueByCategoryAndMonthAndYearAndUser(@Param("year") int year, @Param("month") int month);
+
+  /**
+   * Busca uma lista de {@link ValueByCategoryResponse}, agrupando todas as despesas por categoria em dado mês (month)
+   * e ano (year)e por usuário.
+   *
+   * @param year  ano ao qual as despesas devem pertencer.
+   * @param month mês ao qual as despesas devem pertencer.
+   * @param user  usuário relacionado com as despesas a serem agrupadas.
+   * @return {@code List<ValueByCategoryResponse>} contendo os gastos agrupados por categoria.
+   */
+  @Query("""
+      SELECT new br.com.emendes.financesapi.dto.response.ValueByCategoryResponse(e.category, SUM(e.value))
+         FROM Expense e
+         WHERE YEAR(e.date) = :year AND MONTH(e.date) = :month
+         AND e.user = :user
+         GROUP BY e.category
+      """)
+  List<ValueByCategoryResponse> getValueByCategoryAndMonthAndYearAndUser(
+      @Param("year") int year,
+      @Param("month") int month,
+      @Param("user") User user);
 }

--- a/src/test/java/br/com/emendes/financesapi/integration/repository/ExpenseRepositoryIT.java
+++ b/src/test/java/br/com/emendes/financesapi/integration/repository/ExpenseRepositoryIT.java
@@ -1,0 +1,283 @@
+package br.com.emendes.financesapi.integration.repository;
+
+import br.com.emendes.financesapi.dto.response.ValueByCategoryResponse;
+import br.com.emendes.financesapi.model.Category;
+import br.com.emendes.financesapi.model.entity.Expense;
+import br.com.emendes.financesapi.model.entity.User;
+import br.com.emendes.financesapi.repository.ExpenseRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.data.domain.Page;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.jdbc.Sql;
+import org.springframework.test.context.jdbc.SqlGroup;
+import org.springframework.test.context.jdbc.SqlMergeMode;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+import static br.com.emendes.financesapi.util.constant.ConstantForTesting.PAGEABLE;
+import static br.com.emendes.financesapi.util.constant.SqlPath.*;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Integration tests da camada expense repository interagindo com o banco de dados.
+ */
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@ActiveProfiles("repository-it")
+@DisplayName("Integration tests for ExpenseRepository")
+@SqlGroup({
+    @Sql(scripts = {DROP_DATABASE_TABLES_SQL_PATH, CREATE_DATABASE_TABLES_SQL_PATH})
+})
+class ExpenseRepositoryIT {
+
+  @Autowired
+  private ExpenseRepository expenseRepository;
+
+  @Nested
+  @DisplayName("FindAllByUser method")
+  class FindAllByUserMethod {
+
+    @SqlMergeMode(SqlMergeMode.MergeMode.MERGE)
+    @Sql(scripts = INSERT_MULTIPLE_EXPENSES_AND_MULTIPLE_USERS)
+    @Test
+    @DisplayName("findAllByUser must return page with two expenses when found expenses for given User")
+    void findAllByUser_MustReturnPageWithTwoExpenses_WhenFoundExpensesForGivenUser() {
+      User user = User.builder().id(1L).build();
+
+      Page<Expense> actualExpensePage = expenseRepository.findAllByUser(user, PAGEABLE);
+
+      assertThat(actualExpensePage).isNotNull().hasSize(2);
+    }
+
+    @SqlMergeMode(SqlMergeMode.MergeMode.MERGE)
+    @Sql(scripts = INSERT_USER_SQL_PATH)
+    @Test
+    @DisplayName("findAllByUser must return empty page when not found expenses for given User")
+    void findAllByUser_MustReturnEmptyPage_WhenNotFoundExpensesForGivenUser() {
+      User user = User.builder().id(1L).build();
+
+      Page<Expense> actualExpensePage = expenseRepository.findAllByUser(user, PAGEABLE);
+
+      assertThat(actualExpensePage).isNotNull().isEmpty();
+    }
+
+  }
+
+  @Nested
+  @DisplayName("FindByDescriptionAndUser method")
+  class FindByDescriptionAndUserMethod {
+
+    @SqlMergeMode(SqlMergeMode.MergeMode.MERGE)
+    @Sql(scripts = INSERT_MULTIPLE_EXPENSES_FOR_ONE_USER)
+    @Test
+    @DisplayName("findByDescriptionAndUser must return page with three expenses when found for given user and description 'merc'")
+    void findByDescriptionAndUser_MustReturnPageWithThreeExpenses_WhenFoundForGivenUserAndDescriptionMerc() {
+      User user = User.builder().id(1L).build();
+
+      Page<Expense> actualExpensePage = expenseRepository.findByDescriptionAndUser("merc", user, PAGEABLE);
+      assertThat(actualExpensePage).isNotNull().hasSize(3);
+
+      Page<String> actualExpensesDescriptions = actualExpensePage.map(Expense::getDescription);
+      assertThat(actualExpensesDescriptions)
+          .isNotNull().hasSize(3)
+          .allMatch(description -> description.toLowerCase().contains("merc"));
+    }
+
+    @SqlMergeMode(SqlMergeMode.MergeMode.MERGE)
+    @Sql(scripts = INSERT_MULTIPLE_EXPENSES_FOR_ONE_USER)
+    @Test
+    @DisplayName("findByDescriptionAndUser must return empty page when not found for given user and description 'mecanico'")
+    void findByDescriptionAndUser_MustReturnEmptyPage_WhenNotFoundForGivenUserAndDescriptionMecanico() {
+      User user = User.builder().id(1L).build();
+
+      Page<Expense> actualExpensePage = expenseRepository.findByDescriptionAndUser("mecanico", user, PAGEABLE);
+      assertThat(actualExpensePage).isNotNull().isEmpty();
+    }
+
+  }
+
+  @Nested
+  @DisplayName("FindByYearAndMonthAndUser method")
+  class FindByYearAndMonthAndUserMethod {
+
+    @SqlMergeMode(SqlMergeMode.MergeMode.MERGE)
+    @Sql(scripts = INSERT_MULTIPLE_EXPENSES_FOR_ONE_USER)
+    @Test
+    @DisplayName("findByYearAndMonthAndUser must return Page with three expenses when found for given user, year and month")
+    void findByYearAndMonthAndUser_MustReturnPageWithThreeExpenses_WhenFoundForGivenUserAndYearAndMonth() {
+      User user = User.builder().id(1L).build();
+
+      Page<Expense> actualExpensePage = expenseRepository.findByYearAndMonthAndUser(2023, 2, user, PAGEABLE);
+      assertThat(actualExpensePage).isNotNull().hasSize(3);
+
+      Page<LocalDate> actualExpensesDescriptions = actualExpensePage.map(Expense::getDate);
+      assertThat(actualExpensesDescriptions)
+          .isNotNull().hasSize(3)
+          .allMatch(date -> date.getYear() == 2023 && date.getMonthValue() == 2);
+    }
+
+    @SqlMergeMode(SqlMergeMode.MergeMode.MERGE)
+    @Sql(scripts = INSERT_MULTIPLE_EXPENSES_FOR_ONE_USER)
+    @Test
+    @DisplayName("findByYearAndMonthAndUser must return empty Page when not found for given user, year and month")
+    void findByYearAndMonthAndUser_MustReturnEmptyPage_WhenNotFoundForGivenUserAndYearAndMonth() {
+      User user = User.builder().id(2L).build();
+
+      Page<Expense> actualExpensePage = expenseRepository.findByYearAndMonthAndUser(2021, 11, user, PAGEABLE);
+      assertThat(actualExpensePage).isNotNull().isEmpty();
+    }
+
+    @SqlMergeMode(SqlMergeMode.MergeMode.MERGE)
+    @Sql(scripts = INSERT_MULTIPLE_EXPENSES_FOR_ONE_USER)
+    @Test
+    @DisplayName("findByYearAndMonthAndUser must return empty Page when not found for given user")
+    void findByYearAndMonthAndUser_MustReturnEmptyPage_WhenNotFoundForGivenUser() {
+      User user = User.builder().id(2L).build();
+
+      Page<Expense> actualExpensePage = expenseRepository.findByYearAndMonthAndUser(2023, 3, user, PAGEABLE);
+      assertThat(actualExpensePage).isNotNull().isEmpty();
+    }
+
+    @SqlMergeMode(SqlMergeMode.MergeMode.MERGE)
+    @Sql(scripts = INSERT_MULTIPLE_EXPENSES_FOR_ONE_USER)
+    @Test
+    @DisplayName("findByYearAndMonthAndUser must return empty Page when not found for given year")
+    void findByYearAndMonthAndUser_MustReturnEmptyPage_WhenNotFoundForGivenYear() {
+      User user = User.builder().id(1L).build();
+
+      Page<Expense> actualExpensePage = expenseRepository.findByYearAndMonthAndUser(2021, 3, user, PAGEABLE);
+      assertThat(actualExpensePage).isNotNull().isEmpty();
+    }
+
+    @SqlMergeMode(SqlMergeMode.MergeMode.MERGE)
+    @Sql(scripts = INSERT_MULTIPLE_EXPENSES_FOR_ONE_USER)
+    @Test
+    @DisplayName("findByYearAndMonthAndUser must return empty Page when not found for given month")
+    void findByYearAndMonthAndUser_MustReturnEmptyPage_WhenNotFoundForGivenMonth() {
+      User user = User.builder().id(1L).build();
+
+      Page<Expense> actualExpensePage = expenseRepository.findByYearAndMonthAndUser(2023, 11, user, PAGEABLE);
+      assertThat(actualExpensePage).isNotNull().isEmpty();
+    }
+
+  }
+
+  @Nested
+  @DisplayName("FindByIdAndUser method")
+  class FindByIdAndUserMethod {
+
+    @SqlMergeMode(SqlMergeMode.MergeMode.MERGE)
+    @Sql(scripts = INSERT_MULTIPLE_EXPENSES_FOR_ONE_USER)
+    @Test
+    @DisplayName("findByIdAndUser must return Optional<Expense> when found for given id and user")
+    void findByIdAndUser_MustReturnPageWithThreeExpenses_WhenFoundForGivenIdAndUser() {
+      User user = User.builder().id(1L).build();
+
+      Optional<Expense> actualExpenseOptional = expenseRepository.findByIdAndUser(2L, user);
+      assertThat(actualExpenseOptional).isNotNull().isNotEmpty();
+    }
+
+    @SqlMergeMode(SqlMergeMode.MergeMode.MERGE)
+    @Sql(scripts = INSERT_MULTIPLE_EXPENSES_FOR_ONE_USER)
+    @Test
+    @DisplayName("findByIdAndUser must return empty Optional when not found for given id and user")
+    void findByIdAndUser_MustReturnEmptyOptional_WhenNotFoundForGivenIdAndUser() {
+      User user = User.builder().id(2L).build();
+
+      Optional<Expense> actualExpenseOptional = expenseRepository.findByIdAndUser(100L, user);
+      assertThat(actualExpenseOptional).isNotNull().isEmpty();
+    }
+
+    @SqlMergeMode(SqlMergeMode.MergeMode.MERGE)
+    @Sql(scripts = INSERT_MULTIPLE_EXPENSES_FOR_ONE_USER)
+    @Test
+    @DisplayName("findByIdAndUser must return empty Optional when not found for given id")
+    void findByIdAndUser_MustReturnEmptyOptional_WhenNotFoundForGivenId() {
+      User user = User.builder().id(1L).build();
+
+      Optional<Expense> actualExpenseOptional = expenseRepository.findByIdAndUser(100L, user);
+      assertThat(actualExpenseOptional).isNotNull().isEmpty();
+    }
+
+    @SqlMergeMode(SqlMergeMode.MergeMode.MERGE)
+    @Sql(scripts = INSERT_MULTIPLE_EXPENSES_FOR_ONE_USER)
+    @Test
+    @DisplayName("findByIdAndUser must return empty Optional when not found for given user")
+    void findByIdAndUser_MustReturnEmptyOptional_WhenNotFoundForGivenUser() {
+      User user = User.builder().id(2L).build();
+
+      Optional<Expense> actualExpenseOptional = expenseRepository.findByIdAndUser(1L, user);
+      assertThat(actualExpenseOptional).isNotNull().isEmpty();
+    }
+
+  }
+
+  @Nested
+  @DisplayName("GetValueByCategoryAndMonthAndYearAndUser method")
+  class GetValueByCategoryAndMonthAndYearAndUserMethod {
+
+    @SqlMergeMode(SqlMergeMode.MergeMode.MERGE)
+    @Sql(scripts = INSERT_MULTIPLE_EXPENSES_FOR_ONE_USER)
+    @Test
+    @DisplayName("getValueByCategoryAndMonthAndYearAndUser must return List<ValueByCategoryResponse> when found for given year, month and user")
+    void getValueByCategoryAndMonthAndYearAndUser_MustReturnListValueByCategoryResponse_WhenFoundForGivenYearAndMonthAndUser() {
+      User user = User.builder().id(1L).build();
+
+      List<ValueByCategoryResponse> actualValueByCategoryList = expenseRepository
+          .getValueByCategoryAndMonthAndYearAndUser(2023, 2, user);
+
+      assertThat(actualValueByCategoryList).isNotNull().hasSize(2)
+          .allMatch(valueByCategoryResponse ->
+              valueByCategoryResponse.getCategory().equals(Category.MORADIA) ||
+              valueByCategoryResponse.getCategory().equals(Category.ALIMENTACAO));
+    }
+
+    @SqlMergeMode(SqlMergeMode.MergeMode.MERGE)
+    @Sql(scripts = INSERT_MULTIPLE_EXPENSES_FOR_ONE_USER)
+    @Test
+    @DisplayName("getValueByCategoryAndMonthAndYearAndUser must return empty List when not found for given user")
+    void getValueByCategoryAndMonthAndYearAndUser_MustReturnEmptyList_WhenNotFoundForGivenUser() {
+      User user = User.builder().id(2L).build();
+
+      List<ValueByCategoryResponse> actualValueByCategoryList = expenseRepository
+          .getValueByCategoryAndMonthAndYearAndUser(2023, 2, user);
+
+      assertThat(actualValueByCategoryList).isNotNull().isEmpty();
+    }
+
+    @SqlMergeMode(SqlMergeMode.MergeMode.MERGE)
+    @Sql(scripts = INSERT_MULTIPLE_EXPENSES_FOR_ONE_USER)
+    @Test
+    @DisplayName("getValueByCategoryAndMonthAndYearAndUser must return empty List when not found for given year")
+    void getValueByCategoryAndMonthAndYearAndUser_MustReturnEmptyList_WhenNotFoundForGivenYear() {
+      User user = User.builder().id(1L).build();
+
+      List<ValueByCategoryResponse> actualValueByCategoryList = expenseRepository
+          .getValueByCategoryAndMonthAndYearAndUser(2021, 2, user);
+
+      assertThat(actualValueByCategoryList).isNotNull().isEmpty();
+    }
+
+    @SqlMergeMode(SqlMergeMode.MergeMode.MERGE)
+    @Sql(scripts = INSERT_MULTIPLE_EXPENSES_FOR_ONE_USER)
+    @Test
+    @DisplayName("getValueByCategoryAndMonthAndYearAndUser must return empty List when not found for given month")
+    void getValueByCategoryAndMonthAndYearAndUser_MustReturnEmptyList_WhenNotFoundForGivenMonth() {
+      User user = User.builder().id(1L).build();
+
+      List<ValueByCategoryResponse> actualValueByCategoryList = expenseRepository
+          .getValueByCategoryAndMonthAndYearAndUser(2021, 11, user);
+
+      assertThat(actualValueByCategoryList).isNotNull().isEmpty();
+    }
+
+  }
+
+}

--- a/src/test/java/br/com/emendes/financesapi/util/constant/SqlPath.java
+++ b/src/test/java/br/com/emendes/financesapi/util/constant/SqlPath.java
@@ -8,9 +8,22 @@ public class SqlPath {
   public static final String DROP_DATABASE_TABLES_SQL_PATH = "/sql/database/drop_database_tables.sql";
 
   public static final String INSERT_ADMIN_SQL_PATH = "/sql/user/insert-admin.sql";
+  /**
+   * Path para um arquivo que insere um usuário com a role 'USER'.
+   */
   public static final String INSERT_USER_SQL_PATH = "/sql/user/insert-user.sql";
   public static final String INSERT_INCOMES_EXPENSES_SQL_PATH = "/sql/summary/insert-incomes-and-expenses.sql";
   public static final String INSERT_INCOME_SQL_PATH = "/sql/income/insert-income.sql";
+
+  /**
+   * Path para um arquivo SQL que insere dois usuários e 2 (duas) despesas (expenses) para cada usuário.
+   */
+  public static final String INSERT_MULTIPLE_EXPENSES_AND_MULTIPLE_USERS = "/sql/expense/insert-multiple-expenses-and-multiple-users.sql";
+
+  /**
+   * Path para um arquivo SQL que insere um usuário e 5 (cinco) despesas (expenses) para o usuário.
+   */
+  public static final String INSERT_MULTIPLE_EXPENSES_FOR_ONE_USER = "/sql/expense/insert-multiple-expenses-for-one-user.sql";
   public static final String INSERT_EXPENSE_SQL_PATH = "/sql/expense/insert-expense.sql";
 
 }

--- a/src/test/resources/sql/expense/insert-multiple-expenses-and-multiple-users.sql
+++ b/src/test/resources/sql/expense/insert-multiple-expenses-and-multiple-users.sql
@@ -1,0 +1,16 @@
+-- Add os usuários.
+INSERT INTO tb_user (name, email, password) VALUES
+    ('John Doe', 'john.doe@email.com', '{bcrypt}$2a$10$g8ZNLct0Rcoyq2mExowkheD7GdQzwj/UNl7JvQnk.UiXnIFwt4be6'),
+    ('Jane Doe', 'jane.doe@email.com', '{bcrypt}$2a$10$g8ZNLct0Rcoyq2mExowkheD7GdQzwj/UNl7JvQnk.UiXnIFwt4be6');
+
+-- Add roles dos usuários.
+INSERT INTO tb_user_roles (user_id, roles_id) VALUES
+    (1, 1),
+    (2, 1);
+
+-- Add as despesas (expenses) dos usuários.
+INSERT INTO tb_expense (description, value, date, category, user_id) VALUES
+    ('Aluguel', 1500.00, '2023-02-05', 'MORADIA', 1),
+    ('Supermercado', 325.00, '2023-02-13', 'ALIMENTACAO', 1),
+    ('Aluguel', 1200.00, '2023-02-05', 'MORADIA', 2),
+    ('Supermercado', 175.00, '2023-02-13', 'ALIMENTACAO', 2);

--- a/src/test/resources/sql/expense/insert-multiple-expenses-for-one-user.sql
+++ b/src/test/resources/sql/expense/insert-multiple-expenses-for-one-user.sql
@@ -1,0 +1,15 @@
+-- Add usuário.
+INSERT INTO tb_user (name, email, password) VALUES
+    ('John Doe', 'john.doe@email.com', '{bcrypt}$2a$10$g8ZNLct0Rcoyq2mExowkheD7GdQzwj/UNl7JvQnk.UiXnIFwt4be6');
+
+-- Add role do usuário.
+INSERT INTO tb_user_roles (user_id, roles_id) VALUES
+    (1, 1);
+
+-- Add as despesas (expenses) do usuário.
+INSERT INTO tb_expense (description, value, date, category, user_id) VALUES
+    ('Aluguel', 1500.00, '2023-02-05', 'MORADIA', 1),
+    ('Supermercado', 325.00, '2023-02-06', 'ALIMENTACAO', 1),
+    ('Mercado', 200.00, '2023-02-13', 'ALIMENTACAO', 1),
+    ('MERCEARIA', 75.00, '2023-03-04', 'ALIMENTACAO', 1),
+    ('Aluguel', 1500.00, '2023-03-05', 'MORADIA', 1);


### PR DESCRIPTION
- As queries em *ExpenseRepository* estavam fortemente acopladas ao *Principal* (usuário autenticado no momento), então removi esse acoplamento removendo as buscas por *principal* e colocando por *user*, delegando para o cliente de *ExpenseRepository* fornecer o *user* em cada query, dessa maneira, uma query que era:
  ```java
    @Query("SELECT e FROM Expense e WHERE e.user.id = ?#{ principal?.id }")
    Page<Expense> findAllByUser(Pageable pageable);
  ```
  Passou a ser: 
  ```java
    @Query("SELECT e FROM Expense e WHERE e.user = :user")
    Page<Expense> findAllByUser(@Param("user") User user, Pageable pageable);
  ```
  
  Essa mudança facilitará a manutenção, leitura e a implementação dos testes automatizados.

- Adicionei testes de integração entre a camada *ExpenseRepository* com Banco de dados.