### PR TITLE
refact: desacoplando as queries de IncomeRepository do usuário autenticado no sistema

### DIFF
--- a/src/main/java/br/com/emendes/financesapi/repository/ExpenseRepository.java
+++ b/src/main/java/br/com/emendes/financesapi/repository/ExpenseRepository.java
@@ -74,7 +74,7 @@ public interface ExpenseRepository extends JpaRepository<Expense, Long> {
    * @param month    mês em que foi feito a despesa.
    * @param user     usuário relacionado com as despesas a serem buscadas.
    * @param pageable objeto que define como será feito a paginação (page, size e sort).
-   * @return Objeto {@code Page<Expense>} com as despesas que satisfação as restrições acima.
+   * @return Objeto {@code Page<Expense>} com as despesas que satisfaçam as restrições acima.
    */
   @Query("""
       SELECT e FROM Expense e

--- a/src/main/java/br/com/emendes/financesapi/repository/IncomeRepository.java
+++ b/src/main/java/br/com/emendes/financesapi/repository/IncomeRepository.java
@@ -1,6 +1,7 @@
 package br.com.emendes.financesapi.repository;
 
 import br.com.emendes.financesapi.model.entity.Income;
+import br.com.emendes.financesapi.model.entity.User;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -14,29 +15,113 @@ import java.util.Optional;
 @Repository
 public interface IncomeRepository extends JpaRepository<Income, Long> {
 
+  @Deprecated
   @Query("SELECT i FROM Income i WHERE i.user.id = ?#{ principal?.id }")
   Page<Income> findAllByUser(Pageable pageable);
 
+  /**
+   * Busca paginada de receitas (incomes) para um dado usuário (user).
+   *
+   * @param user     usuário relacionado com as receitas a serem buscadas.
+   * @param pageable objeto que define como será a paginação (page, size e sort).
+   * @return Objeto {@code Page<Income>} com as receitas encontradas para o dado user e pageable.
+   */
+  @Query("SELECT i FROM Income i WHERE i.user = :user")
+  Page<Income> findAllByUser(@Param("user") User user, Pageable pageable);
+
+  @Deprecated
   @Query("SELECT i FROM Income i " +
-      "WHERE lower_unaccent(i.description) LIKE lower_unaccent('%' || :description || '%') " +
-      "AND i.user.id = ?#{ principal?.id }")
+         "WHERE lower_unaccent(i.description) LIKE lower_unaccent('%' || :description || '%') " +
+         "AND i.user.id = ?#{ principal?.id }")
   Page<Income> findByDescriptionAndUser(
       @Param("description") String description,
       Pageable pageable);
 
+  /**
+   * Busca paginada de receitas (incomes) para um dado usuário (user) e descrição (description).<br>
+   * <br>
+   * OBS: A descrição da receita não precisa ser igual a description passada como parâmetro, e sim conte-la.
+   * Ou seja, uma description 'Salário' seria buscada por exêmplo para parâmetros 'sal', 'Sala', 'RIO'.
+   *
+   * @param description descrição que as receitas devem conter para serem buscadas.
+   * @param pageable    objeto que define como será feito a paginação (page, size e sort).
+   * @param user        usuário relacionado com as receitas a serem buscadas.
+   * @return Objeto {@code Page<Income>} com as receitas encontradas para o dado user, description e pageable.
+   */
+  @Query("""
+      SELECT i FROM Income i
+        WHERE lower(unaccent(i.description)) LIKE lower(unaccent('%' || :description || '%'))
+        AND i.user = :user
+      """)
+  Page<Income> findByDescriptionAndUser(
+      @Param("description") String description,
+      @Param("user") User user,
+      Pageable pageable);
+
+  @Deprecated
   @Query("SELECT i FROM Income i WHERE YEAR(i.date) = :year " +
-      "AND MONTH(i.date) = :month AND i.user.id = ?#{ principal?.id }")
+         "AND MONTH(i.date) = :month AND i.user.id = ?#{ principal?.id }")
   Page<Income> findByYearAndMonthAndUser(
       @Param("year") int year,
       @Param("month") int month,
       Pageable pageable);
 
+  /**
+   * Busca paginada de receitas (incomes) por ano (year), mês (month) e usuário (user).
+   *
+   * @param year     ano em que foi feito a receita.
+   * @param month    mês em que foi feito a receita.
+   * @param user     usuário relacionado com as receitas a serem buscadas.
+   * @param pageable objeto que define como será feito a paginação (page, size e sort).
+   * @return Objeto {@code Page<Income>} com as receitas que satisfaçam as restrições acima.
+   */
+  @Query("""
+      SELECT i FROM Income i
+        WHERE YEAR(i.date) = :year
+        AND MONTH(i.date) = :month AND i.user = :user
+      """)
+  Page<Income> findByYearAndMonthAndUser(
+      @Param("year") int year,
+      @Param("month") int month,
+      @Param("user") User user,
+      Pageable pageable);
+
+  @Deprecated
   @Query("SELECT SUM(i.value) FROM Income i WHERE YEAR(i.date) = :year " +
-      "AND MONTH(i.date) = :month AND i.user.id = ?#{ principal?.id }")
+         "AND MONTH(i.date) = :month AND i.user.id = ?#{ principal?.id }")
   Optional<BigDecimal> getTotalValueByMonthAndYearAndUser(
       @Param("year") int year,
       @Param("month") int month);
 
+  /**
+   * Retorna a soma de todas as receitas (incomes) com o mesmo ano (year), mês (month) e usuário (user).
+   *
+   * @param year  ano em que foi feito a receita.
+   * @param month mês em que foi feito a receita
+   * @param user  usuário relacionado com as receitas a serem buscadas.
+   * @return {@code Optional<BigDecimal>} contendo a soma total, ou empty caso não encontre nenhuma receita que
+   * satisfaça as condições acima.
+   */
+  @Query("""
+      SELECT SUM(i.value) FROM Income i WHERE YEAR(i.date) = :year
+        AND MONTH(i.date) = :month AND i.user = :user
+      """)
+  Optional<BigDecimal> getTotalValueByMonthAndYearAndUser(
+      @Param("year") int year,
+      @Param("month") int month,
+      @Param("user") User user);
+
+  @Deprecated
   @Query("SELECT i FROM Income i WHERE i.id = :id AND i.user.id = ?#{ principal?.id }")
   Optional<Income> findByIdAndUser(Long id);
+
+  /**
+   * Busca receita (income) por id e user.
+   *
+   * @param id   identificador da receita.
+   * @param user usuário relacionado com a receita a ser buscada.
+   * @return Objeto {@code Optional<Income>} com a receita encontrada, ou empty caso contrário.
+   */
+  @Query("SELECT i FROM Income i WHERE i.id = :id AND i.user = :user")
+  Optional<Income> findByIdAndUser(@Param("id") Long id, @Param("user") User user);
 }

--- a/src/test/java/br/com/emendes/financesapi/integration/repository/ExpenseRepositoryIT.java
+++ b/src/test/java/br/com/emendes/financesapi/integration/repository/ExpenseRepositoryIT.java
@@ -91,6 +91,22 @@ class ExpenseRepositoryIT {
     }
 
     @SqlMergeMode(SqlMergeMode.MergeMode.MERGE)
+    @Sql(scripts = INSERT_MULTIPLE_EXPENSES_AND_MULTIPLE_USERS)
+    @Test
+    @DisplayName("findByDescriptionAndUser must return page with one expense when exists expense with same description for different users")
+    void findByDescriptionAndUser_MustReturnPageWithOneExpense_WhenExistsExpenseWithSameDescriptionForDifferentUsers() {
+      User user = User.builder().id(1L).build();
+
+      Page<Expense> actualExpensePage = expenseRepository.findByDescriptionAndUser("aluguel", user, PAGEABLE);
+      assertThat(actualExpensePage).isNotNull().hasSize(1);
+
+      Page<String> actualExpensesDescriptions = actualExpensePage.map(Expense::getDescription);
+      assertThat(actualExpensesDescriptions)
+          .isNotNull().hasSize(1)
+          .allMatch(description -> description.toLowerCase().contains("aluguel"));
+    }
+
+    @SqlMergeMode(SqlMergeMode.MergeMode.MERGE)
     @Sql(scripts = INSERT_MULTIPLE_EXPENSES_FOR_ONE_USER)
     @Test
     @DisplayName("findByDescriptionAndUser must return empty page when not found for given user and description 'mecanico'")
@@ -98,6 +114,18 @@ class ExpenseRepositoryIT {
       User user = User.builder().id(1L).build();
 
       Page<Expense> actualExpensePage = expenseRepository.findByDescriptionAndUser("mecanico", user, PAGEABLE);
+      assertThat(actualExpensePage).isNotNull().isEmpty();
+    }
+
+
+    @SqlMergeMode(SqlMergeMode.MergeMode.MERGE)
+    @Sql(scripts = INSERT_MULTIPLE_EXPENSES_AND_MULTIPLE_USERS)
+    @Test
+    @DisplayName("findByDescriptionAndUser must return empty page when not found for given user")
+    void findByDescriptionAndUser_MustReturnEmptyPage_WhenNotFoundForGivenUser() {
+      User user = User.builder().id(1L).build();
+
+      Page<Expense> actualExpensePage = expenseRepository.findByDescriptionAndUser("super", user, PAGEABLE);
       assertThat(actualExpensePage).isNotNull().isEmpty();
     }
 
@@ -120,6 +148,22 @@ class ExpenseRepositoryIT {
       Page<LocalDate> actualExpensesDescriptions = actualExpensePage.map(Expense::getDate);
       assertThat(actualExpensesDescriptions)
           .isNotNull().hasSize(3)
+          .allMatch(date -> date.getYear() == 2023 && date.getMonthValue() == 2);
+    }
+
+    @SqlMergeMode(SqlMergeMode.MergeMode.MERGE)
+    @Sql(scripts = INSERT_MULTIPLE_EXPENSES_AND_MULTIPLE_USERS)
+    @Test
+    @DisplayName("findByYearAndMonthAndUser must return Page with two expenses when exists expenses with same year and month and different users")
+    void findByYearAndMonthAndUser_MustReturnPageWithTwoExpenses_WhenExistsExpenseWithSameYearAndMonthAndDifferentUsers() {
+      User user = User.builder().id(1L).build();
+
+      Page<Expense> actualExpensePage = expenseRepository.findByYearAndMonthAndUser(2023, 2, user, PAGEABLE);
+      assertThat(actualExpensePage).isNotNull().hasSize(2);
+
+      Page<LocalDate> actualExpensesDescriptions = actualExpensePage.map(Expense::getDate);
+      assertThat(actualExpensesDescriptions)
+          .isNotNull().hasSize(2)
           .allMatch(date -> date.getYear() == 2023 && date.getMonthValue() == 2);
     }
 

--- a/src/test/java/br/com/emendes/financesapi/integration/repository/IncomeRepositoryIT.java
+++ b/src/test/java/br/com/emendes/financesapi/integration/repository/IncomeRepositoryIT.java
@@ -1,0 +1,334 @@
+package br.com.emendes.financesapi.integration.repository;
+
+import br.com.emendes.financesapi.model.entity.Income;
+import br.com.emendes.financesapi.model.entity.User;
+import br.com.emendes.financesapi.repository.IncomeRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.data.domain.Page;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.jdbc.Sql;
+import org.springframework.test.context.jdbc.SqlGroup;
+import org.springframework.test.context.jdbc.SqlMergeMode;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.Optional;
+
+import static br.com.emendes.financesapi.util.constant.ConstantForTesting.PAGEABLE;
+import static br.com.emendes.financesapi.util.constant.SqlPath.*;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Integration tests da camada income repository interagindo com o banco de dados.
+ */
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@ActiveProfiles("repository-it")
+@DisplayName("Integration tests for IncomeRepository")
+@SqlGroup({
+    @Sql(scripts = {DROP_DATABASE_TABLES_SQL_PATH, CREATE_DATABASE_TABLES_SQL_PATH})
+})
+class IncomeRepositoryIT {
+
+  @Autowired
+  private IncomeRepository incomeRepository;
+
+  @Nested
+  @DisplayName("FindAllByUser method")
+  class FindAllByUserMethod {
+
+    @SqlMergeMode(SqlMergeMode.MergeMode.MERGE)
+    @Sql(scripts = INSERT_MULTIPLE_INCOMES_AND_MULTIPLE_USERS)
+    @Test
+    @DisplayName("findAllByUser must return page with two incomes when found incomes for given User")
+    void findAllByUser_MustReturnPageWithTwoIncomes_WhenFoundIncomesForGivenUser() {
+      User user = User.builder().id(1L).build();
+
+      Page<Income> actualIncomePage = incomeRepository.findAllByUser(user, PAGEABLE);
+
+      assertThat(actualIncomePage).isNotNull().hasSize(2);
+    }
+
+    @SqlMergeMode(SqlMergeMode.MergeMode.MERGE)
+    @Sql(scripts = INSERT_MULTIPLE_INCOMES_AND_MULTIPLE_USERS)
+    @Test
+    @DisplayName("findAllByUser must return empty page when not found incomes for given User")
+    void findAllByUser_MustReturnEmptyPage_WhenNotFoundIncomesForGivenUser() {
+      User user = User.builder().id(5L).build();
+
+      Page<Income> actualIncomePage = incomeRepository.findAllByUser(user, PAGEABLE);
+
+      assertThat(actualIncomePage).isNotNull().isEmpty();
+    }
+
+  }
+
+  @Nested
+  @DisplayName("FindByDescriptionAndUser method")
+  class FindByDescriptionAndUserMethod {
+
+    @SqlMergeMode(SqlMergeMode.MergeMode.MERGE)
+    @Sql(scripts = INSERT_MULTIPLE_INCOMES_FOR_ONE_USER)
+    @Test
+    @DisplayName("findByDescriptionAndUser must return page with two incomes when found for given user and description 'sala'")
+    void findByDescriptionAndUser_MustReturnPageWithTwoIncomes_WhenFoundForGivenUserAndDescriptionSala() {
+      User user = User.builder().id(1L).build();
+
+      Page<Income> actualIncomePage = incomeRepository.findByDescriptionAndUser("sala", user, PAGEABLE);
+      assertThat(actualIncomePage).isNotNull().hasSize(2);
+
+      Page<String> actualIncomesDescriptions = actualIncomePage.map(Income::getDescription);
+      assertThat(actualIncomesDescriptions)
+          .isNotNull().hasSize(2)
+          .allMatch(description -> description.toLowerCase().contains("salá"));
+    }
+
+    @SqlMergeMode(SqlMergeMode.MergeMode.MERGE)
+    @Sql(scripts = INSERT_MULTIPLE_INCOMES_AND_MULTIPLE_USERS)
+    @Test
+    @DisplayName("findByDescriptionAndUser must return page with one income when exists income with same description for different users")
+    void findByDescriptionAndUser_MustReturnPageWithOneIncome_WhenExistsIncomeWithSameDescriptionForDifferentUsers() {
+      User user = User.builder().id(1L).build();
+
+      Page<Income> actualIncomePage = incomeRepository.findByDescriptionAndUser("sala", user, PAGEABLE);
+      assertThat(actualIncomePage).isNotNull().hasSize(1);
+
+      Page<String> actualIncomesDescriptions = actualIncomePage.map(Income::getDescription);
+      assertThat(actualIncomesDescriptions)
+          .isNotNull().hasSize(1)
+          .allMatch(description -> description.toLowerCase().contains("salá"));
+    }
+
+    @SqlMergeMode(SqlMergeMode.MergeMode.MERGE)
+    @Sql(scripts = INSERT_MULTIPLE_INCOMES_FOR_ONE_USER)
+    @Test
+    @DisplayName("findByDescriptionAndUser must return empty page when not found for given user and description 'venda brechó'")
+    void findByDescriptionAndUser_MustReturnEmptyPage_WhenNotFoundForGivenUserAndDescriptionVendaBrecho() {
+      User user = User.builder().id(1L).build();
+
+      Page<Income> actualIncomePage = incomeRepository.findByDescriptionAndUser("venda brechó", user, PAGEABLE);
+      assertThat(actualIncomePage).isNotNull().isEmpty();
+    }
+
+    @SqlMergeMode(SqlMergeMode.MergeMode.MERGE)
+    @Sql(scripts = INSERT_MULTIPLE_INCOMES_AND_MULTIPLE_USERS)
+    @Test
+    @DisplayName("findByDescriptionAndUser must return empty page when not found for given user")
+    void findByDescriptionAndUser_MustReturnEmptyPage_WhenNotFoundForGivenUser() {
+      User user = User.builder().id(1L).build();
+
+      Page<Income> actualIncomePage = incomeRepository.findByDescriptionAndUser("venda", user, PAGEABLE);
+      assertThat(actualIncomePage).isNotNull().isEmpty();
+    }
+
+  }
+
+  @Nested
+  @DisplayName("FindByYearAndMonthAndUser method")
+  class FindByYearAndMonthAndUserMethod {
+
+    @SqlMergeMode(SqlMergeMode.MergeMode.MERGE)
+    @Sql(scripts = INSERT_MULTIPLE_INCOMES_FOR_ONE_USER)
+    @Test
+    @DisplayName("findByYearAndMonthAndUser must return Page with three incomes when found for given user, year and month")
+    void findByYearAndMonthAndUser_MustReturnPageWithThreeIncomes_WhenFoundForGivenUserAndYearAndMonth() {
+      User user = User.builder().id(1L).build();
+
+      Page<Income> actualIncomePage = incomeRepository.findByYearAndMonthAndUser(2023, 2, user, PAGEABLE);
+      assertThat(actualIncomePage).isNotNull().hasSize(3);
+
+      Page<LocalDate> actualIncomesDescriptions = actualIncomePage.map(Income::getDate);
+      assertThat(actualIncomesDescriptions)
+          .isNotNull().hasSize(3)
+          .allMatch(date -> date.getYear() == 2023 && date.getMonthValue() == 2);
+    }
+
+    @SqlMergeMode(SqlMergeMode.MergeMode.MERGE)
+    @Sql(scripts = INSERT_MULTIPLE_INCOMES_AND_MULTIPLE_USERS)
+    @Test
+    @DisplayName("findByYearAndMonthAndUser must return Page with two incomes when exists incomes with same year and month and different users")
+    void findByYearAndMonthAndUser_MustReturnPageWithTwoIncomes_WhenExistsIncomeWithSameYearAndMonthAndDifferentUsers() {
+      User user = User.builder().id(1L).build();
+
+      Page<Income> actualIncomePage = incomeRepository.findByYearAndMonthAndUser(2023, 2, user, PAGEABLE);
+      assertThat(actualIncomePage).isNotNull().hasSize(2);
+
+      Page<LocalDate> actualIncomesDescriptions = actualIncomePage.map(Income::getDate);
+      assertThat(actualIncomesDescriptions)
+          .isNotNull().hasSize(2)
+          .allMatch(date -> date.getYear() == 2023 && date.getMonthValue() == 2);
+    }
+
+    @SqlMergeMode(SqlMergeMode.MergeMode.MERGE)
+    @Sql(scripts = INSERT_MULTIPLE_INCOMES_FOR_ONE_USER)
+    @Test
+    @DisplayName("findByYearAndMonthAndUser must return empty Page when not found for given user, year and month")
+    void findByYearAndMonthAndUser_MustReturnEmptyPage_WhenNotFoundForGivenUserAndYearAndMonth() {
+      User user = User.builder().id(2L).build();
+
+      Page<Income> actualIncomePage = incomeRepository.findByYearAndMonthAndUser(2021, 11, user, PAGEABLE);
+      assertThat(actualIncomePage).isNotNull().isEmpty();
+    }
+
+    @SqlMergeMode(SqlMergeMode.MergeMode.MERGE)
+    @Sql(scripts = INSERT_MULTIPLE_INCOMES_FOR_ONE_USER)
+    @Test
+    @DisplayName("findByYearAndMonthAndUser must return empty Page when not found for given user")
+    void findByYearAndMonthAndUser_MustReturnEmptyPage_WhenNotFoundForGivenUser() {
+      User user = User.builder().id(2L).build();
+
+      Page<Income> actualIncomePage = incomeRepository.findByYearAndMonthAndUser(2023, 3, user, PAGEABLE);
+      assertThat(actualIncomePage).isNotNull().isEmpty();
+    }
+
+    @SqlMergeMode(SqlMergeMode.MergeMode.MERGE)
+    @Sql(scripts = INSERT_MULTIPLE_INCOMES_FOR_ONE_USER)
+    @Test
+    @DisplayName("findByYearAndMonthAndUser must return empty Page when not found for given year")
+    void findByYearAndMonthAndUser_MustReturnEmptyPage_WhenNotFoundForGivenYear() {
+      User user = User.builder().id(1L).build();
+
+      Page<Income> actualIncomePage = incomeRepository.findByYearAndMonthAndUser(2021, 3, user, PAGEABLE);
+      assertThat(actualIncomePage).isNotNull().isEmpty();
+    }
+
+    @SqlMergeMode(SqlMergeMode.MergeMode.MERGE)
+    @Sql(scripts = INSERT_MULTIPLE_INCOMES_FOR_ONE_USER)
+    @Test
+    @DisplayName("findByYearAndMonthAndUser must return empty Page when not found for given month")
+    void findByYearAndMonthAndUser_MustReturnEmptyPage_WhenNotFoundForGivenMonth() {
+      User user = User.builder().id(1L).build();
+
+      Page<Income> actualIncomePage = incomeRepository.findByYearAndMonthAndUser(2023, 11, user, PAGEABLE);
+      assertThat(actualIncomePage).isNotNull().isEmpty();
+    }
+
+  }
+
+  @Nested
+  @DisplayName("FindByIdAndUser method")
+  class FindByIdAndUserMethod {
+
+    @SqlMergeMode(SqlMergeMode.MergeMode.MERGE)
+    @Sql(scripts = INSERT_MULTIPLE_INCOMES_FOR_ONE_USER)
+    @Test
+    @DisplayName("findByIdAndUser must return Optional<Income> when found for given id and user")
+    void findByIdAndUser_MustReturnPageWithThreeIncomes_WhenFoundForGivenIdAndUser() {
+      User user = User.builder().id(1L).build();
+
+      Optional<Income> actualIncomeOptional = incomeRepository.findByIdAndUser(2L, user);
+      assertThat(actualIncomeOptional).isNotNull().isNotEmpty();
+    }
+
+    @SqlMergeMode(SqlMergeMode.MergeMode.MERGE)
+    @Sql(scripts = INSERT_MULTIPLE_INCOMES_FOR_ONE_USER)
+    @Test
+    @DisplayName("findByIdAndUser must return empty Optional when not found for given id and user")
+    void findByIdAndUser_MustReturnEmptyOptional_WhenNotFoundForGivenIdAndUser() {
+      User user = User.builder().id(2L).build();
+
+      Optional<Income> actualIncomeOptional = incomeRepository.findByIdAndUser(100L, user);
+      assertThat(actualIncomeOptional).isNotNull().isEmpty();
+    }
+
+    @SqlMergeMode(SqlMergeMode.MergeMode.MERGE)
+    @Sql(scripts = INSERT_MULTIPLE_INCOMES_FOR_ONE_USER)
+    @Test
+    @DisplayName("findByIdAndUser must return empty Optional when not found for given id")
+    void findByIdAndUser_MustReturnEmptyOptional_WhenNotFoundForGivenId() {
+      User user = User.builder().id(1L).build();
+
+      Optional<Income> actualIncomeOptional = incomeRepository.findByIdAndUser(100L, user);
+      assertThat(actualIncomeOptional).isNotNull().isEmpty();
+    }
+
+    @SqlMergeMode(SqlMergeMode.MergeMode.MERGE)
+    @Sql(scripts = INSERT_MULTIPLE_INCOMES_FOR_ONE_USER)
+    @Test
+    @DisplayName("findByIdAndUser must return empty Optional when not found for given user")
+    void findByIdAndUser_MustReturnEmptyOptional_WhenNotFoundForGivenUser() {
+      User user = User.builder().id(2L).build();
+
+      Optional<Income> actualIncomeOptional = incomeRepository.findByIdAndUser(1L, user);
+      assertThat(actualIncomeOptional).isNotNull().isEmpty();
+    }
+
+  }
+
+  @Nested
+  @DisplayName("GetTotalValueByMonthAndYearAndUser method")
+  class GetTotalValueByMonthAndYearAndUserMethod {
+
+    @SqlMergeMode(SqlMergeMode.MergeMode.MERGE)
+    @Sql(scripts = INSERT_MULTIPLE_INCOMES_FOR_ONE_USER)
+    @Test
+    @DisplayName("getTotalValueByMonthAndYearAndUser must return Optional<BigDecimal> when found for given year, month and user")
+    void getTotalValueByMonthAndYearAndUser_MustReturnOptionalBigDecimal_WhenFoundForGivenYearAndMonthAndUser() {
+      User user = User.builder().id(1L).build();
+
+      Optional<BigDecimal> actualTotalValueByMonthAndYearAndUser = incomeRepository
+          .getTotalValueByMonthAndYearAndUser(2023, 2, user);
+
+      assertThat(actualTotalValueByMonthAndYearAndUser).isNotNull().isNotEmpty().contains(new BigDecimal("4025.00"));
+    }
+
+    @SqlMergeMode(SqlMergeMode.MergeMode.MERGE)
+    @Sql(scripts = INSERT_MULTIPLE_INCOMES_AND_MULTIPLE_USERS)
+    @Test
+    @DisplayName("getTotalValueByMonthAndYearAndUser must return total value only for given user when exists incomes with same year and month and different users")
+    void getTotalValueByMonthAndYearAndUser_MustTotalValueOnlyForGivenUser_WhenExistsIncomesWithSameYearAndMonthAndDifferentUsers() {
+      User user = User.builder().id(1L).build();
+
+      Optional<BigDecimal> actualTotalValueByMonthAndYearAndUser = incomeRepository
+          .getTotalValueByMonthAndYearAndUser(2023, 2, user);
+
+      assertThat(actualTotalValueByMonthAndYearAndUser).isNotNull().isNotEmpty().contains(new BigDecimal("3825.00"));
+    }
+
+    @SqlMergeMode(SqlMergeMode.MergeMode.MERGE)
+    @Sql(scripts = INSERT_MULTIPLE_INCOMES_FOR_ONE_USER)
+    @Test
+    @DisplayName("getTotalValueByMonthAndYearAndUser must return empty Optional when not found for given user")
+    void getTotalValueByMonthAndYearAndUser_MustReturnEmptyOptional_WhenNotFoundForGivenUser() {
+      User user = User.builder().id(2L).build();
+
+      Optional<BigDecimal> actualTotalValueByMonthAndYearAndUser = incomeRepository
+          .getTotalValueByMonthAndYearAndUser(2023, 2, user);
+
+      assertThat(actualTotalValueByMonthAndYearAndUser).isNotNull().isEmpty();
+    }
+
+    @SqlMergeMode(SqlMergeMode.MergeMode.MERGE)
+    @Sql(scripts = INSERT_MULTIPLE_INCOMES_FOR_ONE_USER)
+    @Test
+    @DisplayName("getTotalValueByMonthAndYearAndUser must return empty Optional when not found for given year")
+    void getTotalValueByMonthAndYearAndUser_MustReturnEmptyOptional_WhenNotFoundForGivenYear() {
+      User user = User.builder().id(1L).build();
+
+      Optional<BigDecimal> actualTotalValueByMonthAndYearAndUser = incomeRepository
+          .getTotalValueByMonthAndYearAndUser(2021, 2, user);
+
+      assertThat(actualTotalValueByMonthAndYearAndUser).isNotNull().isEmpty();
+    }
+
+    @SqlMergeMode(SqlMergeMode.MergeMode.MERGE)
+    @Sql(scripts = INSERT_MULTIPLE_INCOMES_FOR_ONE_USER)
+    @Test
+    @DisplayName("getTotalValueByMonthAndYearAndUser must return empty Optional when not found for given month")
+    void getTotalValueByMonthAndYearAndUser_MustReturnEmptyOptional_WhenNotFoundForGivenMonth() {
+      User user = User.builder().id(1L).build();
+
+      Optional<BigDecimal> actualTotalValueByMonthAndYearAndUser = incomeRepository
+          .getTotalValueByMonthAndYearAndUser(2023, 11, user);
+
+      assertThat(actualTotalValueByMonthAndYearAndUser).isNotNull().isEmpty();
+    }
+
+  }
+
+}

--- a/src/test/java/br/com/emendes/financesapi/util/constant/SqlPath.java
+++ b/src/test/java/br/com/emendes/financesapi/util/constant/SqlPath.java
@@ -13,6 +13,15 @@ public class SqlPath {
    */
   public static final String INSERT_USER_SQL_PATH = "/sql/user/insert-user.sql";
   public static final String INSERT_INCOMES_EXPENSES_SQL_PATH = "/sql/summary/insert-incomes-and-expenses.sql";
+
+  /**
+   * Path para um arquivo SQL que insere dois usuários e 2 (duas) receitas (incomes) para cada usuário.
+   */
+  public static final String INSERT_MULTIPLE_INCOMES_AND_MULTIPLE_USERS = "/sql/income/insert-multiple-incomes-and-multiple-users.sql";
+  /**
+   * Path para um arquivo SQL que insere um usuário e 5 (cinco) receitas (incomes) para o usuário.
+   */
+  public static final String INSERT_MULTIPLE_INCOMES_FOR_ONE_USER = "/sql/income/insert-multiple-incomes-for-one-user.sql";
   public static final String INSERT_INCOME_SQL_PATH = "/sql/income/insert-income.sql";
 
   /**

--- a/src/test/resources/sql/income/insert-multiple-incomes-and-multiple-users.sql
+++ b/src/test/resources/sql/income/insert-multiple-incomes-and-multiple-users.sql
@@ -8,9 +8,9 @@ INSERT INTO tb_user_roles (user_id, roles_id) VALUES
     (1, 1),
     (2, 1);
 
--- Add as despesas (expenses) dos usuários.
-INSERT INTO tb_expense (description, value, date, category, user_id) VALUES
-    ('Aluguel', 1500.00, '2023-02-05', 'MORADIA', 1),
-    ('mercado', 325.00, '2023-02-13', 'ALIMENTACAO', 1),
-    ('Aluguel', 1200.00, '2023-02-05', 'MORADIA', 2),
-    ('supermercado', 175.00, '2023-02-13', 'ALIMENTACAO', 2);
+-- Add as receitas (incomes) dos usuários.
+INSERT INTO tb_income (description, value, date, user_id) VALUES
+    ('Salário', 3500.00, '2023-02-08', 1),
+    ('Freela', 325.00, '2023-02-13', 1),
+    ('Salário', 3700.00, '2023-02-05', 2),
+    ('Venda Video Game', 975.00, '2023-02-13', 2);

--- a/src/test/resources/sql/income/insert-multiple-incomes-for-one-user.sql
+++ b/src/test/resources/sql/income/insert-multiple-incomes-for-one-user.sql
@@ -1,0 +1,15 @@
+-- Add usuário.
+INSERT INTO tb_user (name, email, password) VALUES
+    ('John Doe', 'john.doe@email.com', '{bcrypt}$2a$10$g8ZNLct0Rcoyq2mExowkheD7GdQzwj/UNl7JvQnk.UiXnIFwt4be6');
+
+-- Add role do usuário.
+INSERT INTO tb_user_roles (user_id, roles_id) VALUES
+    (1, 1);
+
+-- Add as receitas (incomes) do usuário.
+INSERT INTO tb_income (description, value, date, user_id) VALUES
+    ('Salário', 3500.00, '2023-02-05', 1),
+    ('Freela', 325.00, '2023-02-06', 1),
+    ('Hora extra', 200.00, '2023-02-13', 1),
+    ('Salário', 3400.00, '2023-03-04', 1),
+    ('Hora extra', 1500.00, '2023-03-05', 1);


### PR DESCRIPTION
- As queries em *IncomeRepository* estavam fortemente acopladas ao *Principal* (usuário autenticado no momento), então removi esse acoplamento removendo as buscas por *principal* e colocando por *user*, delegando para o cliente de *IncomeRepository* fornecer o *user* em cada query, dessa maneira, uma query que era:
  ```java
    @Query("SELECT i FROM Income i WHERE i.user.id = ?#{ principal?.id }")
    Page<Income> findAllByUser(Pageable pageable);
  ```
  Passou a ser: 
  ```java
    @Query("SELECT i FROM Income i WHERE i.user = :user")
    Page<Income> findAllByUser(@Param("user") User user, Pageable pageable);
  ```
  
  Essa mudança facilitará a manutenção, leitura e a implementação dos testes automatizados.

- Adicionei testes de integração entre a camada *IncomeRepository* com Banco de dados.