### PR TITLE
build: change base da imagem da aplicação para eclipse-temurin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,4 @@
-FROM openjdk:17-jdk-alpine
-RUN addgroup -S spring && adduser -S spring -G spring
-USER spring:spring
+FROM eclipse-temurin:17-jdk-alpine
 ARG JAR_FILE=target/*.jar
 COPY ${JAR_FILE} app.jar
 ENTRYPOINT ["java", "-Xmx512m", "-Dserver.port=${PORT}","-jar", "/app.jar"]


### PR DESCRIPTION
mudar a imagem base da imagem docker da aplicação para eclipse-temurin, por que a imagem usada antigamente (openjdk) esta *deprecated*, mais informações em [OpenJDK Dockerhub](https://hub.docker.com/_/openjdk)